### PR TITLE
fixed: nil guard

### DIFF
--- a/twitter_activity.rb
+++ b/twitter_activity.rb
@@ -43,7 +43,8 @@ Plugin.create(:twitter_activity) do
   end
 
   on_follow do |by, to|
-    return by.nil? || to.nil?
+    break if by.nil? || to.nil?
+
     by_user_to_user = {
       followee: by[:idname],
       follower: to[:idname] }

--- a/twitter_activity.rb
+++ b/twitter_activity.rb
@@ -43,6 +43,7 @@ Plugin.create(:twitter_activity) do
   end
 
   on_follow do |by, to|
+    return by.nil? || to.nil?
     by_user_to_user = {
       followee: by[:idname],
       follower: to[:idname] }


### PR DESCRIPTION
mikutterが時々強制終了するので`p`を仕込んで次にこの原因で強制終了するのを待っていました。
そうすると以下のログのエラーで終了しました。
行数とかは`p`を仕込んでいたため変わっています。

~~~
NoMethodError undefined method `[]' for nil:NilClass
/home/ncaq/.mikutter/plugin/twitter_activity/twitter_activity.rb:54:in `block (2 levels) in <top (required)>'
/home/ncaq/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/pluggaloid-1.7.0/lib/pluggaloid/listener.rb:25:in `call'
/home/ncaq/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/pluggaloid-1.7.0/lib/pluggaloid/event.rb:241:in `block (2 levels) in call_all_listeners'
/home/ncaq/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/pluggaloid-1.7.0/lib/pluggaloid/event.rb:240:in `each'
/home/ncaq/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/pluggaloid-1.7.0/lib/pluggaloid/event.rb:240:in `block in call_all_listeners'
/home/ncaq/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/pluggaloid-1.7.0/lib/pluggaloid/event.rb:239:in `catch'
/home/ncaq/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/pluggaloid-1.7.0/lib/pluggaloid/event.rb:239:in `call_all_listeners'
/home/ncaq/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/pluggaloid-1.7.0/lib/pluggaloid/event.rb:62:in `block in call'
/home/ncaq/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/delayer-1.2.1/lib/delayer/procedure.rb:26:in `run'
/home/ncaq/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/delayer-1.2.1/lib/delayer/extend.rb:126:in `run_once_without_pop_reserve'
/home/ncaq/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/delayer-1.2.1/lib/delayer/extend.rb:117:in `run_once'
/home/ncaq/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/delayer-1.2.1/lib/delayer.rb:38:in `method_missing'
{MIKUTTER_DIR}/plugin/gtk3/mainloop.rb:23:in `block (2 levels) in mainloop'
{MIKUTTER_DIR}/plugin/gtk3/mainloop.rb:12:in `loop'
{MIKUTTER_DIR}/plugin/gtk3/mainloop.rb:12:in `block in mainloop'
{MIKUTTER_DIR}/plugin/gtk3/mainloop.rb:10:in `catch'
{MIKUTTER_DIR}/plugin/gtk3/mainloop.rb:10:in `mainloop'
{MIKUTTER_DIR}/mikutter.rb:78:in `boot!'
{MIKUTTER_DIR}/mikutter.rb:117:in `<main>'
~~~

ログからエラーの原因は`by`がnilであることだと分かったのでguardを仕込みました。
対処療法ですが、
とりあえずこれでこの要因で強制終了することはなくなるはずです。